### PR TITLE
Vælg automatisk "Medarbejder" i login-flow.

### DIFF
--- a/forward.js
+++ b/forward.js
@@ -123,7 +123,7 @@ function handleUnilogin() {
         const selectedIdp = document.createElement('input');
         selectedIdp.setAttribute('type', 'hidden');
         selectedIdp.setAttribute('name', 'selectedIdp');
-        selectedIdp.setAttribute('value', 'aarhusmedarbejder');
+        selectedIdp.setAttribute('value', 'jammerbugt');
         form.appendChild(selectedIdp);
         form.submit();
     }

--- a/manifest.json
+++ b/manifest.json
@@ -31,6 +31,14 @@
         "*://youtube.com/",
         "*consent.youtube.com*"
       ]
+    },
+    {
+      "js": [
+        "medarbejder.js"
+      ],
+      "matches": [
+        "https://broker.unilogin.dk/auth/realms/broker/login-actions/post-broker-login*"
+      ]
     }
   ],
   "background": {

--- a/medarbejder.js
+++ b/medarbejder.js
@@ -1,0 +1,4 @@
+'use strict';
+
+document.getElementsByName('selected-aktoer')[0].value = "MEDARBEJDER_EKSTERN";
+document.forms[0].submit();


### PR DESCRIPTION
I skal selvfølgelig ikke ændre "SelectedIdp" til "Jammerbugt"...

Jeg har tilføjet et nyt content script - "medarbejder.js", som bliver fyret af, når loginflowet rammer "post-broker-login", fordi jeg er træt af at skulle vælge "Medarbejder" på siden.